### PR TITLE
Added support for SNMP scans

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,14 @@ ENV PHPSAML_VERSION 2.10.6
 ENV WEB_REPO /var/www/html
 
 # Install required deb packages
-RUN apt-get update && apt-get -y upgrade && \
+RUN sed -i /etc/apt/sources.list -e 's/$/ non-free'/ && \
+    apt-get update && apt-get -y upgrade && \
     rm /etc/apt/preferences.d/no-debian-php && \
-    apt-get install -y libcurl4-gnutls-dev libgmp-dev libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg-dev libpng-dev libldap2-dev libsnmp-dev && \
+    apt-get install -y libcurl4-gnutls-dev libgmp-dev libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg-dev libpng-dev libldap2-dev libsnmp-dev snmp-mibs-downloader && \
     rm -rf /var/lib/apt/lists/*
 
 # Install required packages and files required for snmp
-RUN echo "deb http://ftp.br.debian.org/debian/ wheezy main contrib non-free" > /etc/apt/sources.list && \
-    apt-get update && apt-get install -y snmp-mibs-downloader && \
-    rm -rf /var/lib/apt/lists/* && \
-    curl -s ftp://ftp.cisco.com/pub/mibs/v2/CISCO-SMI.my -o /var/lib/mibs/ietf/CISCO-SMI.txt && \
+RUN curl -s ftp://ftp.cisco.com/pub/mibs/v2/CISCO-SMI.my -o /var/lib/mibs/ietf/CISCO-SMI.txt && \
     curl -s ftp://ftp.cisco.com/pub/mibs/v2/CISCO-TC.my -o /var/lib/mibs/ietf/CISCO-TC.txt && \
     curl -s ftp://ftp.cisco.com/pub/mibs/v2/CISCO-VTP-MIB.my -o /var/lib/mibs/ietf/CISCO-VTP-MIB.txt && \
     curl -s ftp://ftp.cisco.com/pub/mibs/v2/MPLS-VPN-MIB.my -o /var/lib/mibs/ietf/MPLS-VPN-MIB.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,26 @@ ENV WEB_REPO /var/www/html
 # Install required deb packages
 RUN apt-get update && apt-get -y upgrade && \
     rm /etc/apt/preferences.d/no-debian-php && \
-    apt-get install -y php-pear php5-curl php5-mysql php5-json php5-gmp php5-mcrypt php5-ldap php5-gd php-net-socket libgmp-dev libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg-dev libpng-dev libldap2-dev && \
+    apt-get install -y libcurl4-gnutls-dev libgmp-dev libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg-dev libpng-dev libldap2-dev libsnmp-dev && \
     rm -rf /var/lib/apt/lists/*
+
+# Install required packages and files required for snmp
+RUN echo "deb http://ftp.br.debian.org/debian/ wheezy main contrib non-free" > /etc/apt/sources.list && \
+    apt-get update && apt-get install -y snmp-mibs-downloader && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -s ftp://ftp.cisco.com/pub/mibs/v2/CISCO-SMI.my -o /var/lib/mibs/ietf/CISCO-SMI.txt && \
+    curl -s ftp://ftp.cisco.com/pub/mibs/v2/CISCO-TC.my -o /var/lib/mibs/ietf/CISCO-TC.txt && \
+    curl -s ftp://ftp.cisco.com/pub/mibs/v2/CISCO-VTP-MIB.my -o /var/lib/mibs/ietf/CISCO-VTP-MIB.txt && \
+    curl -s ftp://ftp.cisco.com/pub/mibs/v2/MPLS-VPN-MIB.my -o /var/lib/mibs/ietf/MPLS-VPN-MIB.txt
 
 # Configure apache and required PHP modules
 RUN docker-php-ext-configure mysqli --with-mysqli=mysqlnd && \
     docker-php-ext-install mysqli && \
     docker-php-ext-configure gd --enable-gd-native-ttf --with-freetype-dir=/usr/include/freetype2 --with-png-dir=/usr/include --with-jpeg-dir=/usr/include && \
     docker-php-ext-install gd && \
+    docker-php-ext-install curl && \
+    docker-php-ext-install json && \
+    docker-php-ext-install snmp && \
     docker-php-ext-install sockets && \
     docker-php-ext-install pdo_mysql && \
     docker-php-ext-install gettext && \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here, we store data on the host system under `/my_dir/phpipam` and use a specifi
 ### Phpipam 
 
 ```bash
-$ docker run -ti -d -p 80:80 -e MYSQL_ENV_MYSQL_PASSWORD=my-secret-pw--name ipam --link phpipam-mysql:mysql pierrecdn/phpipam
+$ docker run -ti -d -p 80:80 -e MYSQL_ENV_MYSQL_PASSWORD=my-secret-pw --name ipam --link phpipam-mysql:mysql pierrecdn/phpipam
 ```
 
 We are linking the two containers and expose the HTTP port. 


### PR DESCRIPTION
Now everything is fine on my eyes:

- First I corrected a little typo on README.md on docker run of ipam;
- Second I got rid of all "apt-get install" of php-* extensions, since we got redundancy with the "docker-php-ext-configure/install" and used only the later;
- Third, added the snmp support for the phpipam, that needed the devlib of snmp, the extension of php, and the mibfiles to be interpreted the right way.

To test the SNMP support I used the network emulator [GNS3](https://www.gns3.com) and added a device on phpipam, and then scanned the device for data with success (got some errors on VRF and VTP scans, but it's not library related, because of the emulation restrictions).

Please, feel free to make your own tests, any questions just ask.

Thanks for the image by the way, it was helping me a lot!