### PR TITLE
Add fping / update README with discover & ping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV WEB_REPO /var/www/html
 RUN sed -i /etc/apt/sources.list -e 's/$/ non-free'/ && \
     apt-get update && apt-get -y upgrade && \
     rm /etc/apt/preferences.d/no-debian-php && \
-    apt-get install -y libcurl4-gnutls-dev libgmp-dev libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg-dev libpng-dev libldap2-dev libsnmp-dev snmp-mibs-downloader && \
+    apt-get install -y --no-install-recommends fping libcurl4-gnutls-dev libgmp-dev libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg-dev libpng-dev libldap2-dev libsnmp-dev snmp-mibs-downloader && \
     rm -rf /var/lib/apt/lists/*
 
 # Install required packages and files required for snmp
@@ -64,4 +64,3 @@ RUN cp ${WEB_REPO}/config.dist.php ${WEB_REPO}/config.php && \
     ${WEB_REPO}/config.php
 
 EXPOSE 80
-

--- a/README.md
+++ b/README.md
@@ -18,25 +18,45 @@ Run a MySQL database, dedicated to phpipam
 $ docker run --name phpipam-mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw -v /my_dir/phpipam:/var/lib/mysql -d mysql:5.6
 ```
 
-Here, we store data on the host system under `/my_dir/phpipam` and use a specific root password. 
+Here, we store data on the host system under `/my_dir/phpipam` and use a specific root password.
 
-### Phpipam 
+### Phpipam
 
 ```bash
 $ docker run -ti -d -p 80:80 -e MYSQL_ENV_MYSQL_PASSWORD=my-secret-pw --name ipam --link phpipam-mysql:mysql pierrecdn/phpipam
 ```
 
-We are linking the two containers and expose the HTTP port. 
+We are linking the two containers and expose the HTTP port.
+
+#### Ping and discovery
+
+Ping
+
+```bash
+$ docker run -ti -d -e MYSQL_ENV_MYSQL_PASSWORD=my-secret-pw --name ipamping --link phpipam-mysql:mysql pierrecdn/phpipam /usr/local/bin/php /var/www/html/functions/scripts/pingCheck.php
+```
+
+Discovery
+
+```bash
+$ docker run -ti -d -e MYSQL_ENV_MYSQL_PASSWORD=my-secret-pw --name ipamdiscovery --link phpipam-mysql:mysql /usr/local/bin/php /var/www/html/functions/scripts/discoveryCheck.php
+```
+
+Increase Memory in php for Discovery !!! If discovery fails with exhausted memory.
+
+```bash
+$ docker run -ti -d -e MYSQL_ENV_MYSQL_PASSWORD=my-secret-pw --name ipamdiscovery --link phpipam-mysql:mysql pierrecdn/phpipam /usr/local/bin/php -d memory_limit=512M -f /var/www/html/functions/scripts/discoveryCheck.php
+```
 
 ### Specific integration (HTTPS, multi-host containers, etc.)
 
-Regarding your requirements and docker setup, you've to expose resources. 
+Regarding your requirements and docker setup, you've to expose resources.
 
-For HTTPS, run a reverse-proxy in front of your phpipam container and link it to. 
+For HTTPS, run a reverse-proxy in front of your phpipam container and link it to.
 
-For multi-host containers, expose ports, run etcd or consul to make service discovery works etc. 
+For multi-host containers, expose ports, run etcd or consul to make service discovery works etc.
 
-### Configuration 
+### Configuration
 
 * Browse to `http://<ip>[:<specific_port>]/install/`
 * Step 1 : Choose 'Automatic database installation'
@@ -52,11 +72,11 @@ For multi-host containers, expose ports, run etcd or consul to make service disc
 
 ![step3](https://cloud.githubusercontent.com/assets/4225738/8746790/0c434bf6-2c8d-11e5-9ae7-b7d1021b7aa0.png)
 
-* You're done ! 
+* You're done !
 
 ![done](https://cloud.githubusercontent.com/assets/4225738/8746792/0d6fa34e-2c8d-11e5-8002-3793361ae34d.png)
 
-### Docker compose 
+### Docker compose
 
 You can also create an all-in-one YAML deployment descriptor with Docker compose, like this:
 
@@ -87,7 +107,7 @@ volumes:
 
 And next :
 
-```bash 
+```bash
 $ docker-compose up -d
 ```
 
@@ -110,5 +130,5 @@ The secret can be created by running `echo my-secret-pw | docker secret create p
 
 ### Notes
 
-phpIPAM is under heavy development by the amazing Miha. 
-To upgrade the release version, just change the `PHPIPAM_VERSION` environment variable to the target release (see [here](https://github.com/phpipam/phpipam/releases)) 
+phpIPAM is under heavy development by the amazing Miha.
+To upgrade the release version, just change the `PHPIPAM_VERSION` environment variable to the target release (see [here](https://github.com/phpipam/phpipam/releases))


### PR DESCRIPTION
Sorry I create a new pull, i don't know how to clear the older one.

- Add fping in the container (fast discover)
- Some clean space with apt-get not install recommends [example in the link](http://xubuntugeek.blogspot.com/2012/06/save-disk-space-with-apt-get-option-no.html)
- Add readme for make ping and discovery

If you use a docker orchestrator, you can use the same container image to program the image with a cron job, so you do not have to modify the container at any time and launch 3 containers:

1.- PHPIPAM
2.- PING
3.- DISCOVER

and divide the process.

I do not know if the explanation has been clear, if something is missing, you tell me.