### PR TITLE
Removing trailing slashes from source urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM php:5.6-apache
 MAINTAINER Pierre Cheynier <pierre.cheynier@gmail.com>
 
-ENV PHPIPAM_SOURCE https://github.com/phpipam/phpipam/
+ENV PHPIPAM_SOURCE https://github.com/phpipam/phpipam
 ENV PHPIPAM_VERSION 1.3.2
-ENV PHPMAILER_SOURCE https://github.com/PHPMailer/PHPMailer/
+ENV PHPMAILER_SOURCE https://github.com/PHPMailer/PHPMailer
 ENV PHPMAILER_VERSION 5.2.21
-ENV PHPSAML_SOURCE https://github.com/onelogin/php-saml/
+ENV PHPSAML_SOURCE https://github.com/onelogin/php-saml
 ENV PHPSAML_VERSION 2.10.6
 ENV WEB_REPO /var/www/html
 


### PR DESCRIPTION
Trailing slash ended in double slashes in gitlab URLs which would not download somehow. Removing them allows to build the docker image.