### PR TITLE
Added crontab support and switched to MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ---
 
 Update:
-12/12/18 - Modified to inlcude support for crontab and switched to using MariaDB from MySQL
+12/12/18 - Modified to include support for crontab and switched to using MariaDB from MySQL
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # docker-phpipam
 
+---
+
+Update:
+12/12/18 - Modified to inlcude support for crontab and switched to using MariaDB from MySQL
+
+---
+
 phpIPAM is an open-source web IP address management application. Its goal is to provide light and simple IP address management application.
 
 phpIPAM is developed and maintained by Miha Petkovsek, released under the GPL v3 license, project source is [here](https://github.com/phpipam/phpipam)
@@ -10,7 +17,9 @@ Learn more on [phpIPAM homepage](http://phpipam.net)
 
 ## How to use this Docker image
 
-### Mysql
+### MySQL
+
+Note:  MariaDB is now used instead of MySQL.  The same commands will work though as MariaDB is a mostly drop-in replacement for MySQL.
 
 Run a MySQL database, dedicated to phpipam
 
@@ -55,6 +64,12 @@ For multi-host containers, expose ports, run etcd or consul to make service disc
 * You're done ! 
 
 ![done](https://cloud.githubusercontent.com/assets/4225738/8746792/0d6fa34e-2c8d-11e5-8002-3793361ae34d.png)
+
+### Crontab support
+
+Crontab support has been added.  By default the scan and ping scripts are run every 15 minutes.  
+
+You can modify this by making changes to the crontab file under the config directory and restating the container
 
 ### Docker compose 
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:5.6-apache
-MAINTAINER Pierre Cheynier <pierre.cheynier@gmail.com>
+LABEL "Author"="Pierre Cheynier <pierre.cheynier@gmail.com>"
+LABEL "Modificaitons for cron"=" Stacy Olivas <kg7qin@arrl.net>"
 
 ENV PHPIPAM_SOURCE https://github.com/phpipam/phpipam/
 ENV PHPIPAM_VERSION 1.3.2
@@ -13,8 +14,8 @@ ENV WEB_REPO /var/www/html
 RUN sed -i /etc/apt/sources.list -e 's/$/ non-free'/ && \
     apt-get update && apt-get -y upgrade && \
     rm /etc/apt/preferences.d/no-debian-php && \
-    apt-get install -y libcurl4-gnutls-dev libgmp-dev libmcrypt-dev libfreetype6-dev libjpeg-dev libpng-dev libldap2-dev libsnmp-dev snmp-mibs-downloader iputils-ping && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y libcurl4-gnutls-dev libgmp-dev libmcrypt-dev libfreetype6-dev libjpeg-dev libpng-dev libldap2-dev libsnmp-dev snmp-mibs-downloader iputils-ping cron mariadb-client && \
+    rm -rf /var/lib/apt/lists/* 
 
 # Install required packages and files required for snmp
 RUN mkdir -p /var/lib/mibs/ietf && \
@@ -46,6 +47,8 @@ RUN docker-php-ext-configure mysqli --with-mysqli=mysqlnd && \
 
 COPY php.ini /usr/local/etc/php/
 
+COPY ./crontab /etc/
+
 # Copy phpipam sources to web dir
 ADD ${PHPIPAM_SOURCE}/archive/${PHPIPAM_VERSION}.tar.gz /tmp/
 RUN tar -xzf /tmp/${PHPIPAM_VERSION}.tar.gz -C ${WEB_REPO}/ --strip-components=1
@@ -70,3 +73,11 @@ RUN cp ${WEB_REPO}/config.dist.php ${WEB_REPO}/config.php && \
     ${WEB_REPO}/config.php
 
 EXPOSE 80
+
+COPY ./entrypoint.sh /entrypoint.sh
+
+RUN /bin/chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+

--- a/build/crontab
+++ b/build/crontab
@@ -1,0 +1,5 @@
+#run phpipam cron jobs
+#path for scripts in container: /var/www/html/functions/scripts
+# update host status every 15 minutes
+*/15 * * * * /usr/local/bin/php /var/www/html/functions/scripts/pingCheck.php
+*/15 * * * * /usr/local/bin/php /var/www/html/functions/scripts/discoveryCheck.php

--- a/build/crontab
+++ b/build/crontab
@@ -1,5 +1,5 @@
 #run phpipam cron jobs
 #path for scripts in container: /var/www/html/functions/scripts
 # update host status every 15 minutes
-*/15 * * * * /usr/local/bin/php /var/www/html/functions/scripts/pingCheck.php
-*/15 * * * * /usr/local/bin/php /var/www/html/functions/scripts/discoveryCheck.php
+*/15 * * * * root /usr/local/bin/php /var/www/html/functions/scripts/pingCheck.php
+*/15 * * * * root /usr/local/bin/php /var/www/html/functions/scripts/discoveryCheck.php

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# copy over the crontab file from the host at /config
+CT="/config/crontab"
+
+if [ -f "$CT" ]; then
+	/bin/echo "* Copying /config/crontab to /etc/crontab"
+	/bin/cp /config/crontab /etc
+fi
+
+
+# wait until MySQL is really available before starting cron and continuing with phpipam startup
+maxcounter=60
+ 
+counter=1
+while ! mysql --protocol TCP -u"$MYSQL_ENV_MYSQL_USER" -p"$MYSQL_ENV_MYSQL_PASSWORD" -h"$MYSQL_ENV_MYSQL_HOST" -e "show databases;" > /dev/null 2>&1; do
+    sleep 1
+    counter=`expr $counter + 1`
+    if [ $counter -gt $maxcounter ]; then
+        >&2 echo "We have been waiting for MySQL too long already; failing."
+        exit 1
+    fi;
+done
+
+/bin/echo "* Starting cron service"
+# start the cron service in teh container
+/usr/sbin/service cron start
+exec /usr/local/bin/docker-php-entrypoint apache2-foreground
+

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -22,6 +22,10 @@ while ! mysql --protocol TCP -u"$MYSQL_ENV_MYSQL_USER" -p"$MYSQL_ENV_MYSQL_PASSW
     fi;
 done
 
+#Work around Debian 9 "bug" with cron and Docker
+/bin/echo "* Setting up for cron"
+/usr/bin/touch /etc/crontab /etc/cron.*/*
+
 /bin/echo "* Starting cron service"
 # start the cron service in teh container
 /usr/sbin/service cron start

--- a/build/php.ini
+++ b/build/php.ini
@@ -70,3 +70,4 @@ url_rewriter.tags = "a=href,area=href,frame=src,input=src,form=fakeentry"
 [ldap]
 ldap.max_links = -1
 
+

--- a/config/crontab
+++ b/config/crontab
@@ -1,0 +1,5 @@
+#run phpipam cron jobs
+#path for scripts in container: /var/www/html/functions/scripts
+# update host status every 15 minutes
+*/15 * * * * /usr/local/bin/php /var/www/html/functions/scripts/pingCheck.php
+*/15 * * * * /usr/local/bin/php /var/www/html/functions/scripts/discoveryCheck.php

--- a/config/crontab
+++ b/config/crontab
@@ -1,5 +1,5 @@
 #run phpipam cron jobs
 #path for scripts in container: /var/www/html/functions/scripts
 # update host status every 15 minutes
-*/15 * * * * /usr/local/bin/php /var/www/html/functions/scripts/pingCheck.php
-*/15 * * * * /usr/local/bin/php /var/www/html/functions/scripts/discoveryCheck.php
+*/15 * * * * root /usr/local/bin/php /var/www/html/functions/scripts/pingCheck.php
+*/15 * * * * root /usr/local/bin/php /var/www/html/functions/scripts/discoveryCheck.php

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '2'
+
+services:
+  mysql: 
+    image: mariadb
+    environment:
+      - MYSQL_ROOT_PASSWORD=my-password
+    restart: always
+    volumes:
+      - ./db_data/mysql:/var/lib/mysql
+    container_name: phpipam_mysql
+  ipam:
+    depends_on:
+      - mysql
+    build: ./build/
+    restart: always
+    environment:
+      - MYSQL_ENV_MYSQL_USER=root
+      - MYSQL_ENV_MYSQL_PASSWORD=my-password
+      - MYSQL_ENV_MYSQL_HOST=mysql
+    container_name: phpipam
+    ports:
+      - "8080:80"
+    volumes:
+      - ./config:/config
+
+
+


### PR DESCRIPTION
A few changes were made:

- Switched from MySQL to MariaDB
- Added support for crontab with the ability to change the crontab file and restart the container for the changes to take effect.

I also changed how this is built.  By default now it uses docker-compose to build the container.  This was done to support the changes that I made and allow the ability to update the contab file in the config directory and restart the container for the changes to take effect.

An entrypoint.sh file was added.  This file will wait 90 seconds for MariaDB to be ready and either continue with initialization or quit.  Once MariaDB is ready, the script will then start the cron service then execute the default entry point of docker-php-entrypoint with the argument of apache2-foreground, which starts Apache and PHP.

Additionally the database is now persistent across container rebuilds.  Data from MariaDB is now kept in db_data/mysql.

