### PR TITLE
Update version to 1.4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.2-apache
 MAINTAINER Pierre Cheynier <pierre.cheynier@gmail.com>
 
 ENV PHPIPAM_SOURCE https://github.com/phpipam/phpipam/
-ENV PHPIPAM_VERSION 1.4.2
+ENV PHPIPAM_VERSION 1.4.4
 ENV PHPMAILER_SOURCE https://github.com/PHPMailer/PHPMailer/
 ENV PHPMAILER_VERSION 5.2.21
 ENV PHPSAML_SOURCE https://github.com/onelogin/php-saml/


### PR DESCRIPTION
https://github.com/phpipam/phpipam/releases

```
1.4.4 Bugfixes:
----------------------------
+ Allow UTF-8 in instruction widgets (#3360);
+ Exclude IPv6 from Ping and Discovery scans (#3354);

Security Fixes:
----------------------------
+ XSS (reflected) in IP calculator (#3351);
+ XSS in pass-change/result.php (#3373);


1.4.3 Bugfixes:
----------------------------
+ FPing discovery marks all addresses as alive (#2888);
+ SNMP, number of discovered hosts exceed maximum warning (#3279);

Security Fixes:
----------------------------
+ PHP session ID fixation (#3342);
```