### PR TITLE
dep: bump `phpipam` version to latest `v1.6.0` tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.2-apache
 MAINTAINER Pierre Cheynier <pierre.cheynier@gmail.com>
 
 ENV PHPIPAM_SOURCE https://github.com/phpipam/phpipam/
-ARG PHPIPAM_VERSION=1.5.2
+ARG PHPIPAM_VERSION=1.6.0
 ENV PHPMAILER_SOURCE https://github.com/PHPMailer/PHPMailer/
 ARG PHPMAILER_VERSION=6.7.1
 ENV PHPSAML_SOURCE https://github.com/onelogin/php-saml/


### PR DESCRIPTION
Changes are just directly to bump `phpipam` image version to latest checkout sha 

https://github.com/phpipam/phpipam/releases/tag/v1.6.0

latest checkout: `0e9ec21c9d95f2bfcf91ffa93da4c4d470821421`