### PR TITLE
Added TRUST_X_FORWARDED_HEADERS environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN cp ${WEB_REPO}/config.dist.php ${WEB_REPO}/config.php && \
     -e "s/\['user'\] = 'phpipam'/\['user'\] = getenv(\"MYSQL_ENV_MYSQL_USER\") ?: \"root\"/" \
     -e "s/\['name'\] = 'phpipam'/\['name'\] = getenv(\"MYSQL_ENV_MYSQL_DB\") ?: \"phpipam\"/" \
     -e "s/\['pass'\] = 'phpipamadmin'/\['pass'\] = getenv(\"MYSQL_ENV_MYSQL_ROOT_PASSWORD\")/" \
+    -e "s/\$trust_x_forwarded_headers = false/\$trust_x_forwarded_headers = boolval(getenv(\"TRUST_X_FORWARDED_HEADERS\")) ?: false/" \
     -e "s/\['port'\] = 3306;/\['port'\] = 3306;\n\n\$password_file = getenv(\"MYSQL_ENV_MYSQL_PASSWORD_FILE\");\nif(file_exists(\$password_file))\n\$db\['pass'\] = preg_replace(\"\/\\\\s+\/\", \"\", file_get_contents(\$password_file));/" \
     -e "s/define('BASE', \"\/\")/define('BASE', getenv(\"PHPIPAM_BASE\"))/" \
     -e "s/\$gmaps_api_key.*/\$gmaps_api_key = getenv(\"GMAPS_API_KEY\") ?: \"\";/" \

--- a/README.md
+++ b/README.md
@@ -105,16 +105,17 @@ The secret can be created by running `echo my-secret-pw | docker secret create p
 Here is the list of the available environment variables in the phpipam container, pass them to docker using `-e`.
 None of them are actually needed to run the container, this is only to tweak the behavior.
 
-| Environment variable           | Default value | Description                                                                                              |
-| ------------------------------ |:-------------:| --------------------------------------------------------------------------------------------------------:|
-| MYSQL_ENV_MYSQL_HOST           | mysql         | The host used to reach the MySQL instance                                                                |
-| MYSQL_ENV_MYSQL_USER           | root          | The user to connect the MySQL instance                                                                   |
-| MYSQL_ENV_MYSQL_ROOT_PASSWORD  | (empty)       | The MySQL password. Can be set using the Web UI during the first install                                 |
-| MYSQL_ENV_MYSQL_DB             | phpipam       | The name of the MySQL DB to connect to                                                                   |
-| MYSQL_ENV_MYSQL_PASSWORD_FILE  | (empty)       | A file containing the password (if not using MYSQL_ROOT_PASSWORD) this allows to leverage docker secrets |
-| PHPIPAM_BASE                   | /             | The base URI under which phpipam runs. Useful when performing rewrites with a reverse-proxy              |
-| GMAPS_API_KEY                  | (empty)       | Google Maps API Key, used to display maps of your devices                                                |
-| GMAPS_API_GEOCODE_KEY          | (empty)       | Google Maps Geocode API Key, used to find coordinates from an address/ a location of your device         |
+| Environment variable          | Default value | Description                                                                                                                                                                               |
+| ----------------------------- |:-------------:| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MYSQL_ENV_MYSQL_HOST          | mysql         | The host used to reach the MySQL instance                                                                                                                                                 |
+| MYSQL_ENV_MYSQL_USER          | root          | The user to connect the MySQL instance                                                                                                                                                    |
+| MYSQL_ENV_MYSQL_ROOT_PASSWORD | (empty)       | The MySQL password. Can be set using the Web UI during the first install                                                                                                                  |
+| MYSQL_ENV_MYSQL_DB            | phpipam       | The name of the MySQL DB to connect to                                                                                                                                                    |
+| MYSQL_ENV_MYSQL_PASSWORD_FILE | (empty)       | A file containing the password (if not using MYSQL_ROOT_PASSWORD) this allows to leverage docker secrets                                                                                  |
+| PHPIPAM_BASE                  | /             | The base URI under which phpipam runs. Useful when performing rewrites with a reverse-proxy                                                                                               |
+| TRUST_X_FORWARDED_HEADERS     | false         | If operating behind a reverse proxy, set to `true` to accept the following headers: `X_FORWARDED_HOST`, `X_FORWARDED_PORT`, `X_FORWARDED_PROTO`, `X_FORWARDED_SSL`, and `X_FORWARDED_URI` |
+| GMAPS_API_KEY                 | (empty)       | Google Maps API Key, used to display maps of your devices                                                                                                                                 |
+| GMAPS_API_GEOCODE_KEY         | (empty)       | Google Maps Geocode API Key, used to find coordinates from an address/ a location of your device                                                                                          |
 
 ### Specific integration (HTTPS, multi-host containers, etc.)
 


### PR DESCRIPTION
The release of phpipam 1.6 [introduced a new config.php setting](https://github.com/phpipam/phpipam/releases/tag/v1.6.0) called `$trust_x_forwarded_headers`. This setting is false by default, and breaks integration between this docker image and reverse proxies, as the X_FORWARDED_FOR_* headers are no longer trusted.

This PR adds a new environment variable to control this setting.

Resolves [#84]